### PR TITLE
Update README with Supabase edge runtime instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ docker compose up --build -d
 
 The application will be reachable at [http://localhost:8080](http://localhost:8080).
 
+## Running Supabase with Edge Functions
+
+The provided `docker-compose.yaml` only starts the Postgres database alongside the
+frontend container. Features such as syncing the NVD database and sending emails
+require Supabase Edge Functions. To run them locally you need the Supabase CLI
+which spins up an additional edge runtime container.
+
+1. Install the Supabase CLI from <https://supabase.com/docs/guides/cli>.
+2. Start the full local stack:
+
+```sh
+supabase start
+```
+
+Use the same credentials as in your `.env` file when prompted. Once the stack is
+running, the edge functions will be available and the "Sync" actions in the UI
+should succeed.
+


### PR DESCRIPTION
## Summary
- document how to start Supabase locally with the edge runtime

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686ace0c63d88325a8d9e76b5b0f6172