### PR TITLE
Fix SMTP notes

### DIFF
--- a/src/components/admin/EmailSettings.tsx
+++ b/src/components/admin/EmailSettings.tsx
@@ -327,10 +327,9 @@ export const EmailSettings = ({
             <p className="font-medium text-blue-900 mb-1">SMTP Setup Notes:</p>
             <ul className="text-blue-800 space-y-1 text-xs">
               <li>• For Gmail: Use smtp.gmail.com, port 587, and create an App Password</li>
-              <li>• For Outlook: Use smtp-mail.outlook.com, port 587</li>
-              <li>• Per Gmail usa un’App Password oppure configura OAuth2 (l’opzione "Less secure app access" non è più disponibile)</li>
+              <li>• For Outlook: Use smtp.office365.com, port 587</li>
               <li>• Check spam folder if test emails don't arrive</li>
-            </ul>
+              </ul>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- remove outdated Italian message from SMTP notes
- update Outlook SMTP host to Office365

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ace5a30b08325b38b29c74ac1bc15