### PR TITLE
Fix edge runtime start command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY}
     volumes:
       - ./supabase/functions:/home/deno/functions
-    command: start --main-service /home/deno/functions --binding 0.0.0.0:9000
+    command: start --main-service /home/deno/functions -i 0.0.0.0 -p 9000
     depends_on:
       - supabase
     ports:


### PR DESCRIPTION
## Summary
- use `-i` and `-p` flags for `edge-runtime` container

## Testing
- `npm run lint`
- `npm test` *(exits watch mode)*


------
https://chatgpt.com/codex/tasks/task_e_686aef29872c83259df4b31b58f8cfda